### PR TITLE
Fix corrupt mapping file

### DIFF
--- a/demo-project-kotlin/app/src/androidUnitTest/kotlin/org/test/kotlin/app/Rethrow.kt
+++ b/demo-project-kotlin/app/src/androidUnitTest/kotlin/org/test/kotlin/app/Rethrow.kt
@@ -2,5 +2,5 @@ package org.test.kotlin.app
 
 actual const val isJVM = true
 
-actual fun rethrow(throwable: () -> Throwable) =
+actual fun rethrow(throwable: Throwable) =
     org.test.kotlin.utils.rethrow(throwable)

--- a/demo-project-kotlin/app/src/commonTest/kotlin/org/test/kotlin/app/AppOwnersTest.kt
+++ b/demo-project-kotlin/app/src/commonTest/kotlin/org/test/kotlin/app/AppOwnersTest.kt
@@ -3,7 +3,6 @@ package org.test.kotlin.app
 import io.github.gmazzo.codeowners.codeOwners
 import io.github.gmazzo.codeowners.codeOwnersOf
 import org.test.kotlin.utils.AppUtils
-import kotlin.jvm.JvmSerializableLambda
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -27,7 +26,7 @@ class AppOwnersTest {
 
     @Test
     fun ownerFromExceptionStacktrace() {
-        val exception = assertFailsWith<AppException> { rethrow @JvmSerializableLambda { AppException("myException") } }
+        val exception = assertFailsWith<AppException> { rethrow(AppException()) }
 
         val expectedOwners = setOf(if (isJVM) "utils-devs" else "app-devs") // on JVM we have stackstraces
 

--- a/demo-project-kotlin/app/src/commonTest/kotlin/org/test/kotlin/app/Rethrow.kt
+++ b/demo-project-kotlin/app/src/commonTest/kotlin/org/test/kotlin/app/Rethrow.kt
@@ -3,8 +3,8 @@ package org.test.kotlin.app
 
 import kotlin.jvm.JvmName
 
-class AppException(message: String) : RuntimeException(message)
+class AppException : RuntimeException("anException")
 
 expect val isJVM: Boolean
 
-expect fun rethrow(throwable: () -> Throwable)
+expect fun rethrow(throwable: Throwable)

--- a/demo-project-kotlin/app/src/jsTest/kotlin/org/test/kotlin/app/Rethrow.kt
+++ b/demo-project-kotlin/app/src/jsTest/kotlin/org/test/kotlin/app/Rethrow.kt
@@ -2,6 +2,6 @@ package org.test.kotlin.app
 
 actual const val isJVM = false
 
-actual fun rethrow(throwable: () -> Throwable) {
-    throw throwable()
+actual fun rethrow(throwable: Throwable) {
+    throw throwable
 }

--- a/demo-project-kotlin/app/src/jvmTest/kotlin/org/test/kotlin/app/Rethrow.kt
+++ b/demo-project-kotlin/app/src/jvmTest/kotlin/org/test/kotlin/app/Rethrow.kt
@@ -2,5 +2,5 @@ package org.test.kotlin.app
 
 actual const val isJVM = true
 
-actual fun rethrow(throwable: () -> Throwable) =
+actual fun rethrow(throwable: Throwable) =
     org.test.kotlin.utils.rethrow(throwable)

--- a/demo-project-kotlin/app/src/nativeTest/kotlin/org/test/kotlin/app/Rethrow.kt
+++ b/demo-project-kotlin/app/src/nativeTest/kotlin/org/test/kotlin/app/Rethrow.kt
@@ -2,6 +2,6 @@ package org.test.kotlin.app
 
 actual const val isJVM = false
 
-actual fun rethrow(throwable: () -> Throwable) {
-    throw throwable()
+actual fun rethrow(throwable: Throwable) {
+    throw throwable
 }

--- a/demo-project-kotlin/lib1/src/test/kotlin/org/test/kotlin/lib/LibOwnersTest.kt
+++ b/demo-project-kotlin/lib1/src/test/kotlin/org/test/kotlin/lib/LibOwnersTest.kt
@@ -21,7 +21,7 @@ class LibOwnersTest {
     @Test
     fun ownerOfMoreUtils() {
         assertEquals(setOf("utils-devs"), MoreUtils::class.java.codeOwners)
-        assertEquals(setOf("utils-more"), MoreUtils.Companion::class.java.codeOwners)
+        assertEquals(setOf("utils-devs"), MoreUtils.Companion::class.java.codeOwners)
     }
 
 }

--- a/demo-project-kotlin/lib2/src/main/kotlin/org/test/kotlin/utils/AndroidLibUtils.kt
+++ b/demo-project-kotlin/lib2/src/main/kotlin/org/test/kotlin/utils/AndroidLibUtils.kt
@@ -4,8 +4,6 @@ import io.github.gmazzo.codeowners.CodeOwners
 
 sealed class AndroidLibUtils {
 
-    // manual override owners
-    @CodeOwners("libs-impl")
     data object Impl : AndroidLibUtils()
 
 }

--- a/demo-project-kotlin/lib2/src/test/kotlin/org/test/kotlin/lib/AndroidLibOwnersTest.kt
+++ b/demo-project-kotlin/lib2/src/test/kotlin/org/test/kotlin/lib/AndroidLibOwnersTest.kt
@@ -10,7 +10,7 @@ class AndroidLibOwnersTest {
     @Test
     fun ownerOfAndroidLib() {
         assertEquals(setOf("libs-devs"), codeOwnersOf<AndroidLibUtils>())
-        assertEquals(setOf("libs-impl"), codeOwnersOf<AndroidLibUtils.Impl>())
+        assertEquals(setOf("libs-devs"), codeOwnersOf<AndroidLibUtils.Impl>())
     }
 
 }

--- a/demo-project-kotlin/utils/src/main/kotlin/org/test/kotlin/utils/Rethrow.kt
+++ b/demo-project-kotlin/utils/src/main/kotlin/org/test/kotlin/utils/Rethrow.kt
@@ -1,5 +1,5 @@
 package org.test.kotlin.utils
 
-fun rethrow(throwable: () -> Throwable) {
-    throw throwable()
+fun rethrow(throwable: Throwable) {
+    throw throwable.javaClass.newInstance()
 }

--- a/demo-project-kotlin/utils/src/main/kotlin/org/test/kotlin/utils/more/MoreUtils.kt
+++ b/demo-project-kotlin/utils/src/main/kotlin/org/test/kotlin/utils/more/MoreUtils.kt
@@ -1,11 +1,7 @@
 package org.test.kotlin.utils.more
 
-import io.github.gmazzo.codeowners.CodeOwners
-
 class MoreUtils {
 
-    // manual override owners
-    @CodeOwners("utils-more")
     companion object
 
 }

--- a/demo-project-kotlin/utils/src/test/java/org/test/kotlin/utils/UtilsOwnersTest.java
+++ b/demo-project-kotlin/utils/src/test/java/org/test/kotlin/utils/UtilsOwnersTest.java
@@ -17,7 +17,7 @@ public class UtilsOwnersTest {
     @Test
     public void ownerOfMoreUtils() {
         assertEquals(setOf("utils-devs"), getCodeOwners(MoreUtils.class));
-        assertEquals(setOf("utils-more"), getCodeOwners(MoreUtils.Companion.class));
+        assertEquals(setOf("utils-devs"), getCodeOwners(MoreUtils.Companion.class));
     }
 
 }

--- a/demo-project-tests/build.gradle.kts
+++ b/demo-project-tests/build.gradle.kts
@@ -17,21 +17,23 @@ testing.suites.withType<JvmTestSuite>().configureEach {
     useJUnitJupiter()
 }
 
-val collectTaskOutputs = copySpec()
 val collectTask = tasks.register<Sync>("collectTaskOutputs") {
-    with(collectTaskOutputs)
     into(temporaryDir)
 }
 
 rootProject.allprojects project@{
     tasks.withType<CodeOwnersResourcesTask>().all task@{
-        collectTaskOutputs.from(files(simplifiedMappedCodeOwnersFile, rawMappedCodeOwnersFile)) {
-            into("actualMappings/${project.path}")
+        collectTask.configure {
+            from(listOf(simplifiedMappedCodeOwnersFile, rawMappedCodeOwnersFile)) {
+                into("actualMappings/${this@task.project.path}")
+            }
         }
     }
     tasks.withType<CodeOwnersReportTask>().all task@{
-        collectTaskOutputs.from(codeOwnersReportFile) {
-            into("actualReports/${project.path}")
+        collectTask.configure {
+            from(codeOwnersReportFile) {
+                into("actualReports/${this@task.project.path}")
+            }
         }
     }
 }

--- a/demo-project-tests/src/test/resources/expectedReports/:demo-project-kotlin:app/app-androidDebugUnitTest.codeowners
+++ b/demo-project-tests/src/test/resources/expectedReports/:demo-project-kotlin:app/app-androidDebugUnitTest.codeowners
@@ -1,6 +1,6 @@
 # CodeOwners of module ':demo-project-kotlin:app' (source set 'androidDebugUnitTest')
 
-org/test/kotlin/app/AppException                                                    app-devs
-org/test/kotlin/app/AppOwnersTest                                                   app-devs
-org/test/kotlin/app/AppOwnersTest$ownerFromExceptionStacktrace$exception$1$1        app-devs
-org/test/kotlin/app/RethrowKt                                                       app-devs
+org/test/kotlin/app/AppException        app-devs
+org/test/kotlin/app/AppOwnersTest       app-devs
+org/test/kotlin/app/RethrowKt           app-devs
+org/test/kotlin/app/RethrowUtils        app-devs

--- a/demo-project-tests/src/test/resources/expectedReports/:demo-project-kotlin:app/app-androidReleaseUnitTest.codeowners
+++ b/demo-project-tests/src/test/resources/expectedReports/:demo-project-kotlin:app/app-androidReleaseUnitTest.codeowners
@@ -1,6 +1,6 @@
 # CodeOwners of module ':demo-project-kotlin:app' (source set 'androidReleaseUnitTest')
 
-org/test/kotlin/app/AppException                                                    app-devs
-org/test/kotlin/app/AppOwnersTest                                                   app-devs
-org/test/kotlin/app/AppOwnersTest$ownerFromExceptionStacktrace$exception$1$1        app-devs
-org/test/kotlin/app/RethrowKt                                                       app-devs
+org/test/kotlin/app/AppException        app-devs
+org/test/kotlin/app/AppOwnersTest       app-devs
+org/test/kotlin/app/RethrowKt           app-devs
+org/test/kotlin/app/RethrowUtils        app-devs

--- a/demo-project-tests/src/test/resources/expectedReports/:demo-project-kotlin:app/app-iosArm64Test.codeowners
+++ b/demo-project-tests/src/test/resources/expectedReports/:demo-project-kotlin:app/app-iosArm64Test.codeowners
@@ -2,3 +2,5 @@
 
 org/test/kotlin/app/AppException        app-devs
 org/test/kotlin/app/AppOwnersTest       app-devs
+org/test/kotlin/app/RethrowKt           app-devs
+org/test/kotlin/app/RethrowUtils        app-devs

--- a/demo-project-tests/src/test/resources/expectedReports/:demo-project-kotlin:app/app-iosSimulatorArm64Test.codeowners
+++ b/demo-project-tests/src/test/resources/expectedReports/:demo-project-kotlin:app/app-iosSimulatorArm64Test.codeowners
@@ -2,3 +2,5 @@
 
 org/test/kotlin/app/AppException        app-devs
 org/test/kotlin/app/AppOwnersTest       app-devs
+org/test/kotlin/app/RethrowKt           app-devs
+org/test/kotlin/app/RethrowUtils        app-devs

--- a/demo-project-tests/src/test/resources/expectedReports/:demo-project-kotlin:app/app-jsTest.codeowners
+++ b/demo-project-tests/src/test/resources/expectedReports/:demo-project-kotlin:app/app-jsTest.codeowners
@@ -2,3 +2,5 @@
 
 org/test/kotlin/app/AppException        app-devs
 org/test/kotlin/app/AppOwnersTest       app-devs
+org/test/kotlin/app/RethrowKt           app-devs
+org/test/kotlin/app/RethrowUtils        app-devs

--- a/demo-project-tests/src/test/resources/expectedReports/:demo-project-kotlin:app/app-jvmTest.codeowners
+++ b/demo-project-tests/src/test/resources/expectedReports/:demo-project-kotlin:app/app-jvmTest.codeowners
@@ -1,8 +1,8 @@
 # CodeOwners of module ':demo-project-kotlin:app' (source set 'jvmTest')
 
-org/test/kotlin/app/AppException                                                    app-devs
-org/test/kotlin/app/AppOwnersJVMTest                                                app-devs
-org/test/kotlin/app/AppOwnersJVMTest$ownerOfUtilFunctions$1                         app-devs
-org/test/kotlin/app/AppOwnersTest                                                   app-devs
-org/test/kotlin/app/AppOwnersTest$ownerFromExceptionStacktrace$exception$1$1        app-devs
-org/test/kotlin/app/RethrowKt                                                       app-devs
+org/test/kotlin/app/AppException                                app-devs
+org/test/kotlin/app/AppOwnersJVMTest                            app-devs
+org/test/kotlin/app/AppOwnersJVMTest$ownerOfUtilFunctions$1     app-devs
+org/test/kotlin/app/AppOwnersTest                               app-devs
+org/test/kotlin/app/RethrowKt                                   app-devs
+org/test/kotlin/app/RethrowUtils                                app-devs

--- a/demo-project-tests/src/test/resources/expectedReports/:demo-project-kotlin:app/app.codeowners
+++ b/demo-project-tests/src/test/resources/expectedReports/:demo-project-kotlin:app/app.codeowners
@@ -1,12 +1,12 @@
 # CodeOwners of module ':demo-project-kotlin:app'
 
-org/test/kotlin/app/AppClass                                                        app-devs
-org/test/kotlin/app/AppException                                                    app-devs
-org/test/kotlin/app/AppOwnersJVMTest                                                app-devs
-org/test/kotlin/app/AppOwnersJVMTest$ownerOfUtilFunctions$1                         app-devs
-org/test/kotlin/app/AppOwnersTest                                                   app-devs
-org/test/kotlin/app/AppOwnersTest$ownerFromExceptionStacktrace$exception$1$1        app-devs
-org/test/kotlin/app/BuildConfig                                                     app-devs
-org/test/kotlin/app/RethrowKt                                                       app-devs
-org/test/kotlin/app/test/BuildConfig                                                app-devs
-org/test/kotlin/utils/AppUtils                                                      app-devs
+org/test/kotlin/app/AppClass                                    app-devs
+org/test/kotlin/app/AppException                                app-devs
+org/test/kotlin/app/AppOwnersJVMTest                            app-devs
+org/test/kotlin/app/AppOwnersJVMTest$ownerOfUtilFunctions$1     app-devs
+org/test/kotlin/app/AppOwnersTest                               app-devs
+org/test/kotlin/app/BuildConfig                                 app-devs
+org/test/kotlin/app/RethrowKt                                   app-devs
+org/test/kotlin/app/RethrowUtils                                app-devs
+org/test/kotlin/app/test/BuildConfig                            app-devs
+org/test/kotlin/utils/AppUtils                                  app-devs

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,6 @@ org.gradle.jvmargs=-Xmx2g
 org.gradle.caching=true
 org.gradle.configuration-cache=true
 org.gradle.parallel=true
+
+# facilitates debugging
+# kotlin.compiler.execution.strategy=in-process

--- a/plugins/kotlin-compiler/src/main/kotlin/io/github/gmazzo/codeowners/compiler/CodeOwnersComponentRegistrar.kt
+++ b/plugins/kotlin-compiler/src/main/kotlin/io/github/gmazzo/codeowners/compiler/CodeOwnersComponentRegistrar.kt
@@ -12,6 +12,7 @@ import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
 import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.fir.extensions.FirExtensionRegistrarAdapter
 import org.jetbrains.kotlin.ir.util.IrMessageLogger
 import org.jetbrains.kotlin.ir.util.irMessageLogger
 
@@ -31,9 +32,12 @@ internal class CodeOwnersComponentRegistrar : CompilerPluginRegistrar() {
         val codeOwnersRoot = configuration.get(CODEOWNERS_ROOT)!!
         val codeOwnersFile = configuration.get(CODEOWNERS_FILE)!!.useLines { CodeOwnersFile(it) }
         val mappingFile = configuration.get(MAPPINGS_OUTPUT)
-        val matcher = CodeOwnersMatcher(codeOwnersRoot, codeOwnersFile)
 
-        IrGenerationExtension.registerExtension(CodeOwnersIrGenerationExtension(matcher, mappingFile))
+        val matcher = CodeOwnersMatcher(codeOwnersRoot, codeOwnersFile)
+        val mappings = CodeOwnersMappings(matcher, mappingFile)
+
+        FirExtensionRegistrarAdapter.registerExtension(CodeOwnersFirExtensionRegistrar(mappings))
+        IrGenerationExtension.registerExtension(CodeOwnersIrGenerationExtension(mappings))
     }
 
 }

--- a/plugins/kotlin-compiler/src/main/kotlin/io/github/gmazzo/codeowners/compiler/CodeOwnersComponentRegistrar.kt
+++ b/plugins/kotlin-compiler/src/main/kotlin/io/github/gmazzo/codeowners/compiler/CodeOwnersComponentRegistrar.kt
@@ -33,8 +33,6 @@ internal class CodeOwnersComponentRegistrar : CompilerPluginRegistrar() {
         val mappingFile = configuration.get(MAPPINGS_OUTPUT)
         val matcher = CodeOwnersMatcher(codeOwnersRoot, codeOwnersFile)
 
-        mappingFile?.delete()
-        mappingFile?.parentFile?.mkdirs()
         IrGenerationExtension.registerExtension(CodeOwnersIrGenerationExtension(matcher, mappingFile))
     }
 

--- a/plugins/kotlin-compiler/src/main/kotlin/io/github/gmazzo/codeowners/compiler/CodeOwnersFirExtensionRegistrar.kt
+++ b/plugins/kotlin-compiler/src/main/kotlin/io/github/gmazzo/codeowners/compiler/CodeOwnersFirExtensionRegistrar.kt
@@ -1,0 +1,14 @@
+package io.github.gmazzo.codeowners.compiler
+
+import org.jetbrains.kotlin.fir.FirSession
+import org.jetbrains.kotlin.fir.extensions.FirExtensionRegistrar
+
+class CodeOwnersFirExtensionRegistrar(
+    private val mappings: CodeOwnersMappings,
+) : FirExtensionRegistrar() {
+
+    override fun ExtensionRegistrarContext.configurePlugin() {
+        +{ session: FirSession -> CodeOwnersFirProcessor(session, mappings) }
+    }
+
+}

--- a/plugins/kotlin-compiler/src/main/kotlin/io/github/gmazzo/codeowners/compiler/CodeOwnersFirProcessor.kt
+++ b/plugins/kotlin-compiler/src/main/kotlin/io/github/gmazzo/codeowners/compiler/CodeOwnersFirProcessor.kt
@@ -1,0 +1,63 @@
+package io.github.gmazzo.codeowners.compiler
+
+import org.jetbrains.kotlin.backend.common.serialization.toIoFileOrNull
+import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
+import org.jetbrains.kotlin.fir.FirElement
+import org.jetbrains.kotlin.fir.FirSession
+import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
+import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
+import org.jetbrains.kotlin.fir.analysis.checkers.declaration.DeclarationCheckers
+import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirFileChecker
+import org.jetbrains.kotlin.fir.analysis.extensions.FirAdditionalCheckersExtension
+import org.jetbrains.kotlin.fir.declarations.FirFile
+import org.jetbrains.kotlin.fir.declarations.FirRegularClass
+import org.jetbrains.kotlin.fir.declarations.FirSimpleFunction
+import org.jetbrains.kotlin.fir.declarations.utils.classId
+import org.jetbrains.kotlin.fir.java.findJvmNameValue
+import org.jetbrains.kotlin.fir.packageFqName
+import org.jetbrains.kotlin.fir.visitors.FirVisitor
+import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.resolve.jvm.JvmClassName
+
+class CodeOwnersFirProcessor(
+    session: FirSession,
+    private val mappings: CodeOwnersMappings,
+) : FirAdditionalCheckersExtension(session) {
+
+    override val declarationCheckers = object : DeclarationCheckers() {
+        override val fileCheckers = setOf(CodeOwnersMapper())
+    }
+
+    inner class CodeOwnersMapper : FirFileChecker(MppCheckerKind.Platform) {
+        override fun check(declaration: FirFile, context: CheckerContext, reporter: DiagnosticReporter) {
+            val mappings = declaration.sourceFile?.toIoFileOrNull()?.let(mappings::resolve) ?: return
+
+            declaration.accept(fileVisitor, mappings)
+        }
+    }
+
+    private val fileVisitor = object : FirVisitor<Unit, CodeOwnersMappings.Mapping>() {
+
+        override fun visitFile(file: FirFile, data: CodeOwnersMappings.Mapping) {
+            file.acceptChildren(this, data)
+
+            if (file.declarations.any { it is FirSimpleFunction }) {
+                val fileJvmName = file.findJvmNameValue() ?: file.name.replace("\\.kt".toRegex(), "Kt")
+                val fileClass = JvmClassName.byFqNameWithoutInnerClasses(file.packageFqName.child(Name.identifier(fileJvmName))).internalName
+
+                data.classes += fileClass
+            }
+        }
+
+        override fun visitRegularClass(regularClass: FirRegularClass, data: CodeOwnersMappings.Mapping) {
+            data.classes += JvmClassName.byClassId(regularClass.classId).internalName
+
+            regularClass.acceptChildren(this, data)
+        }
+
+        override fun visitElement(element: FirElement, data: CodeOwnersMappings.Mapping) {
+        }
+
+    }
+
+}

--- a/plugins/kotlin-compiler/src/main/kotlin/io/github/gmazzo/codeowners/compiler/CodeOwnersIrGenerationExtension.kt
+++ b/plugins/kotlin-compiler/src/main/kotlin/io/github/gmazzo/codeowners/compiler/CodeOwnersIrGenerationExtension.kt
@@ -1,62 +1,19 @@
 package io.github.gmazzo.codeowners.compiler
 
-import io.github.gmazzo.codeowners.matcher.CodeOwnersFile
-import io.github.gmazzo.codeowners.matcher.CodeOwnersMatcher
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
-import java.io.File
-import java.util.LinkedList
-import java.util.concurrent.Executors
-import java.util.concurrent.Future
-import java.util.concurrent.TimeUnit
 
 internal class CodeOwnersIrGenerationExtension(
-    private val matcher: CodeOwnersMatcher,
-    private val mappingsFile: File?,
+    private val mappings: CodeOwnersMappings,
 ) : IrGenerationExtension {
 
-    private val mappings = mappingsFile?.let { mutableMapOf<String, Pair<Set<String>, File>>() }
-
-    private val executor by lazy { Executors.newSingleThreadScheduledExecutor() }
-
-    private var dumpTask: Future<*>? = null
-
     override fun generate(moduleFragment: IrModuleFragment, pluginContext: IrPluginContext) {
-        val transformer = CodeOwnersIrTransformer(pluginContext, matcher, mappings)
+        mappings.noteFrontedFinished()
+
+        val transformer = CodeOwnersIrTransformer(pluginContext, mappings)
 
         moduleFragment.accept(transformer, InvalidOwners)
-
-        if (mappings != null) {
-            postDumpMappings()
-        }
-    }
-
-    private fun postDumpMappings() {
-        dumpTask?.cancel(true)
-        dumpTask = executor.schedule(::dumpMappings, 100, TimeUnit.MILLISECONDS)
-    }
-
-    private fun dumpMappings() {
-        val entries = LinkedList<CodeOwnersFile.Entry>()
-
-        val it = mappings!!.iterator()
-        while (it.hasNext()) {
-            val (jvmClass, entry) = it.next()
-            val (owners, sourceFile) = entry
-
-            if (!sourceFile.isFile) {
-                it.remove()
-
-            } else {
-                entries.add(CodeOwnersFile.Entry(jvmClass, owners.toList()))
-            }
-        }
-
-        with(mappingsFile!!) {
-            parentFile?.mkdirs()
-            writeText(CodeOwnersFile(entries).content)
-        }
     }
 
     private data object InvalidOwners : Set<String> by emptySet() {

--- a/plugins/kotlin-compiler/src/main/kotlin/io/github/gmazzo/codeowners/compiler/CodeOwnersIrGenerationExtension.kt
+++ b/plugins/kotlin-compiler/src/main/kotlin/io/github/gmazzo/codeowners/compiler/CodeOwnersIrGenerationExtension.kt
@@ -6,23 +6,56 @@ import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
 import java.io.File
+import java.util.LinkedList
+import java.util.concurrent.Executors
+import java.util.concurrent.Future
+import java.util.concurrent.TimeUnit
 
 internal class CodeOwnersIrGenerationExtension(
     private val matcher: CodeOwnersMatcher,
     private val mappingsFile: File?,
 ) : IrGenerationExtension {
 
+    private val mappings = mappingsFile?.let { mutableMapOf<String, Pair<Set<String>, File>>() }
+
+    private val executor by lazy { Executors.newSingleThreadScheduledExecutor() }
+
+    private var dumpTask: Future<*>? = null
+
     override fun generate(moduleFragment: IrModuleFragment, pluginContext: IrPluginContext) {
-        val mappings = mappingsFile?.let { mutableMapOf<String, MutableSet<String>>() }
         val transformer = CodeOwnersIrTransformer(pluginContext, matcher, mappings)
 
         moduleFragment.accept(transformer, InvalidOwners)
 
         if (mappings != null) {
-            val entries = mappings.map { (file, owners) -> CodeOwnersFile.Entry(file, owners.toList()) }
-            val codeOwners = CodeOwnersFile(entries)
+            postDumpMappings()
+        }
+    }
 
-            mappingsFile!!.appendText(codeOwners.content)
+    private fun postDumpMappings() {
+        dumpTask?.cancel(true)
+        dumpTask = executor.schedule(::dumpMappings, 100, TimeUnit.MILLISECONDS)
+    }
+
+    private fun dumpMappings() {
+        val entries = LinkedList<CodeOwnersFile.Entry>()
+
+        val it = mappings!!.iterator()
+        while (it.hasNext()) {
+            val (jvmClass, entry) = it.next()
+            val (owners, sourceFile) = entry
+
+            if (!sourceFile.isFile) {
+                it.remove()
+
+            } else {
+                entries.add(CodeOwnersFile.Entry(jvmClass, owners.toList()))
+            }
+        }
+
+        with(mappingsFile!!) {
+            parentFile?.mkdirs()
+            writeText(CodeOwnersFile(entries).content)
         }
     }
 

--- a/plugins/kotlin-compiler/src/main/kotlin/io/github/gmazzo/codeowners/compiler/CodeOwnersMappings.kt
+++ b/plugins/kotlin-compiler/src/main/kotlin/io/github/gmazzo/codeowners/compiler/CodeOwnersMappings.kt
@@ -1,0 +1,40 @@
+package io.github.gmazzo.codeowners.compiler
+
+import io.github.gmazzo.codeowners.matcher.CodeOwnersFile
+import io.github.gmazzo.codeowners.matcher.CodeOwnersMatcher
+import java.io.File
+
+class CodeOwnersMappings(
+    private val matcher: CodeOwnersMatcher,
+    private var mappingFile: File?,
+) {
+
+    private val mappings = mutableMapOf<File, Mapping?>()
+
+    fun resolve(file: File) = mappings.computeIfAbsent(file) {
+        matcher.ownerOf(file)?.let { Mapping(owners = it) }
+    }
+
+    fun noteFrontedFinished() = mappingFile?.let { file ->
+        mappingFile = null
+
+        val entries = mappings.entries.asSequence()
+            .onEach { (file) -> check(file.isFile) { "$file does not exists!" } }
+            .filter { it.value != null }
+            .flatMap { (_, mapping) ->
+                mapping!!.classes.asSequence().map {
+                    CodeOwnersFile.Entry(pattern = it, mapping.owners.toList())
+                }
+            }
+            .toList()
+
+        file.parentFile?.mkdirs()
+        file.writeText(CodeOwnersFile(entries).content)
+    }
+
+    data class Mapping(
+        val classes: MutableSet<String> = mutableSetOf(),
+        val owners: Set<String>,
+    )
+
+}

--- a/plugins/kotlin-core/build.gradle.kts
+++ b/plugins/kotlin-core/build.gradle.kts
@@ -1,6 +1,4 @@
 import org.gradle.configurationcache.extensions.capitalized
-import org.jetbrains.kotlin.gradle.targets.js.ir.KotlinJsIrLink
-import org.jetbrains.kotlin.gradle.tasks.KotlinNativeLink
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)

--- a/plugins/kotlin-core/src/jvmMain/kotlin/io/github/gmazzo/codeowners/CodeOwners.kt
+++ b/plugins/kotlin-core/src/jvmMain/kotlin/io/github/gmazzo/codeowners/CodeOwners.kt
@@ -13,7 +13,7 @@ actual val KClass<*>.codeOwners: Set<String>?
 val Class<*>.codeOwners: Set<String>?
     get() = when {
         Proxy.isProxyClass(this) -> resolveInterfacesIfProxy().mapNotNull { it.codeOwners }.flatten().toSet()
-        else -> getAnnotation(CodeOwners::class.java)?.owners?.toSet()
+        else -> getAnnotation(CodeOwners::class.java)?.owners?.toSet() ?: enclosingClass?.codeOwners
     }
 
 val KFunction<*>.codeOwners: Set<String>?


### PR DESCRIPTION
Changes the approach by combining Fir (frontend) + Ir (backend) components.

Fir will be used to compute mappings (applying to all files, as a validator) and Ir to generate the extra bytecode (annotations+providers, incrementally). 